### PR TITLE
enhancement: Slot 컴포넌트에 ref를 등록할 수 있는 기능 개선 및 테스트 코드 작성

### DIFF
--- a/src/utils/compose-refs.tsx
+++ b/src/utils/compose-refs.tsx
@@ -1,0 +1,32 @@
+import type { Ref } from "react"
+
+type PossibleRef<T> = Ref<T> | undefined
+
+/**
+ * Ref(Callback, Object)를 할당하는 유틸리티 함수
+ * 이 함수는 사용자가 어떠한 Ref 형태와 상관없이 참조 값을 동기화할 수 있도록 합니다.
+ *
+ * @why React의 Ref는 Callback, Object 두 가지를 지원하고 있기 때문입니다.
+ *
+ * @param ref - 할당 대상이 되는 Ref
+ * @param value - Ref에 저장할 실제 값
+ * @see {@link https://ko.react.dev/learn/manipulating-the-dom-with-refs React 공식 문서: Ref로 DOM 조작하기}
+ */
+function setRef<T>(ref: PossibleRef<T>, value: T) {
+  if (typeof ref === "function") {
+    ref(value)
+  } else if (ref !== null && ref !== undefined) {
+    ref.current = value
+  }
+}
+
+/**
+ * 여러 개의 ref를 결합하는 유틸리티 함수
+ * @param refs - 결합할 ref 목록
+ * @returns ref를 결합하는 callback 함수
+ *
+ * @see {@link https://github.com/radix-ui/primitives/blob/main/packages/react/compose-refs/src/compose-refs.tsx Radix UI의 composeRefs 참조}
+ */
+export function composeRefs<T>(...refs: PossibleRef<T>[]) {
+  return (node: T) => refs.forEach((ref) => setRef(ref, node))
+}

--- a/src/utils/slot.spec.tsx
+++ b/src/utils/slot.spec.tsx
@@ -1,0 +1,121 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react"
+
+import { fireEvent, render, screen } from "@testing-library/react"
+import { createRef } from "react"
+import { describe, it } from "vitest"
+
+import { Slot } from "./slot"
+import { Slottable } from "./slottable"
+
+describe("Slot 컴포넌트 상세 검증", () => {
+  describe("렌더링 제약 사항", () => {
+    it("자식 요소가 하나라면, 그대로 렌더링 되어야 한다", () => {
+      render(
+        <Slot>
+          <p data-testid="slot-text">Slot</p>
+        </Slot>,
+      )
+      expect(screen.getByTestId("slot-text")).toBeInTheDocument()
+    })
+
+    it("자식 요소가 여러 개라면, 에러를 발생시킨다", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+      expect(() => {
+        render(
+          <Button asChild>
+            <p data-testid="slot-text">Slot</p>
+            <p data-testid="slot-text">Slot</p>
+          </Button>,
+        )
+      }).toThrow()
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe("속성 위임 및 병합", () => {
+    it("Slot 컴포넌트에 전달된 속성이 올바르게 하위 컴포넌트에 전달되어야 한다.", () => {
+      render(
+        <Slot className="parent-class" id="parent-id">
+          <button className="child-class">버튼</button>
+        </Slot>,
+      )
+
+      const button = screen.getByRole("button")
+
+      expect(button).toHaveClass("parent-class")
+      expect(button).toHaveAttribute("id", "parent-id")
+    })
+
+    it("이벤트 핸들러가 하위 컴포넌트로 전달되어 동작해야 한다.", () => {
+      const handleClick = vi.fn()
+
+      render(
+        <Button asChild onClick={handleClick}>
+          <button>버튼</button>
+        </Button>,
+      )
+
+      const button = screen.getByRole("button")
+      fireEvent.click(button)
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("Ref가 자식의 실제 DOM 요소를 올바르게 가리켜야 한다", () => {
+      const ref = createRef<HTMLButtonElement>()
+      render(
+        <Slot ref={ref}>
+          <button>ref 확인</button>
+        </Slot>,
+      )
+
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+      expect(ref.current?.textContent).toBe("ref 확인")
+    })
+  })
+
+  describe("Slottable 컴포넌트 렌더링 테스트", () => {
+    it("Slottable을 사용해 아이콘과 동적 자식이 올바르게 조립되어야 한다", () => {
+      render(
+        <Slot>
+          <span data-testid="left-icon">Icon</span>
+          <Slottable>
+            <button data-testid="main-button">Button</button>
+          </Slottable>
+          <span data-testid="right-icon">Icon</span>
+        </Slot>,
+      )
+
+      const button = screen.getByTestId("main-button")
+      const leftIcon = screen.getByTestId("left-icon")
+      const rightIcon = screen.getByTestId("right-icon")
+
+      expect(button).toBeInTheDocument()
+      expect(leftIcon).toBeInTheDocument()
+      expect(rightIcon).toBeInTheDocument()
+    })
+  })
+})
+
+function Button({
+  children,
+  asChild,
+  leftIcon,
+  rightIcon,
+  ...restProps
+}: {
+  asChild: boolean
+  leftIcon?: ReactNode
+  rightIcon?: ReactNode
+} & ButtonHTMLAttributes<HTMLButtonElement>) {
+  const Component = asChild ? Slot : "button"
+
+  return (
+    <Component {...restProps}>
+      {leftIcon}
+      <Slottable>{children}</Slottable>
+      {rightIcon}
+    </Component>
+  )
+}

--- a/src/utils/slot.spec.tsx
+++ b/src/utils/slot.spec.tsx
@@ -73,6 +73,25 @@ describe("Slot 컴포넌트 상세 검증", () => {
       expect(ref.current).toBeInstanceOf(HTMLButtonElement)
       expect(ref.current?.textContent).toBe("ref 확인")
     })
+
+    it("상위의 forwardRef와 하위의 ref가 모두 동일한 DOM 요소를 가리켜야 한다.", () => {
+      const parentRef = createRef<HTMLButtonElement>()
+      const childRef = createRef<HTMLButtonElement>()
+
+      render(
+        <Slot ref={parentRef}>
+          <button ref={childRef} data-testid="target-button">
+            ref 병합
+          </button>
+        </Slot>,
+      )
+
+      const renderedButton = screen.getByTestId("target-button")
+
+      expect(parentRef.current).toBe(renderedButton)
+      expect(childRef.current).toBe(renderedButton)
+      expect(parentRef.current).toBe(childRef.current)
+    })
   })
 
   describe("Slottable 컴포넌트 렌더링 테스트", () => {

--- a/src/utils/slot.tsx
+++ b/src/utils/slot.tsx
@@ -2,6 +2,7 @@ import type { HTMLAttributes, ReactElement, ReactNode, Ref } from "react"
 
 import { Children, cloneElement, forwardRef, isValidElement } from "react"
 
+import { composeRefs } from "./compose-refs"
 import { Slottable } from "./slottable"
 
 type MergePropsWithRef<P> = P & { ref?: Ref<HTMLElement> }
@@ -32,7 +33,14 @@ export const Slot = forwardRef<HTMLElement, SlotProps>(({ children, ...restProps
     })
 
     return isValidElement(newElement)
-      ? cloneElement(newElement, { ...restProps, ref: forwardedRef } as MergePropsWithRef<SlotProps>, newChildren)
+      ? cloneElement(
+          newElement,
+          {
+            ...restProps,
+            ref: composeRefs(forwardedRef, getElementRef(newElement)),
+          } as MergePropsWithRef<SlotProps>,
+          newChildren,
+        )
       : null
   }
 
@@ -42,8 +50,15 @@ export const Slot = forwardRef<HTMLElement, SlotProps>(({ children, ...restProps
   }
 
   return isValidElement(children)
-    ? cloneElement(children, { ...restProps, ref: forwardedRef } as MergePropsWithRef<SlotProps>)
+    ? cloneElement(children, {
+        ...restProps,
+        ref: composeRefs(forwardedRef, getElementRef(children)),
+      } as MergePropsWithRef<SlotProps>)
     : null
 })
 
 Slot.displayName = "Slot"
+
+function getElementRef(element: ReactElement) {
+  return (element.props as { ref?: Ref<unknown> }).ref || (element as unknown as { ref?: Ref<unknown> }).ref
+}

--- a/src/utils/slot.tsx
+++ b/src/utils/slot.tsx
@@ -1,14 +1,16 @@
-import type { HTMLAttributes, ReactElement, ReactNode } from "react"
+import type { HTMLAttributes, ReactElement, ReactNode, Ref } from "react"
 
-import { Children, cloneElement, isValidElement } from "react"
+import { Children, cloneElement, forwardRef, isValidElement } from "react"
 
 import { Slottable } from "./slottable"
+
+type MergePropsWithRef<P> = P & { ref?: Ref<HTMLElement> }
 
 interface SlotProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode
 }
 
-export function Slot({ children, ...restProps }: SlotProps) {
+export const Slot = forwardRef<HTMLElement, SlotProps>(({ children, ...restProps }, forwardedRef) => {
   const childrenArray = Children.toArray(children)
   const slottable = childrenArray.find((child) => isValidElement(child) && child.type === Slottable) as ReactElement<{
     children: ReactNode
@@ -29,7 +31,9 @@ export function Slot({ children, ...restProps }: SlotProps) {
       return isValidElement(newElement) ? (newElement.props as { children: ReactNode }).children : null
     })
 
-    return isValidElement(newElement) ? cloneElement(newElement, restProps, newChildren) : null
+    return isValidElement(newElement)
+      ? cloneElement(newElement, { ...restProps, ref: forwardedRef } as MergePropsWithRef<SlotProps>, newChildren)
+      : null
   }
 
   if (Children.count(children) > 1) {
@@ -37,5 +41,24 @@ export function Slot({ children, ...restProps }: SlotProps) {
     return Children.only(null)
   }
 
-  return isValidElement(children) ? cloneElement(children, restProps) : null
+  return isValidElement(children)
+    ? cloneElement(children, { ...restProps, ref: forwardedRef } as MergePropsWithRef<SlotProps>)
+    : null
+})
+
+Slot.displayName = "Slot"
+
+export function Icon() {
+  return <p>🚀 Icon</p>
+}
+
+export function Button({ asChild, icon, children }: { asChild: boolean; icon: ReactElement; children: ReactNode }) {
+  const Component = asChild ? Slot : "button"
+
+  return (
+    <Component>
+      {icon}
+      {children}
+    </Component>
+  )
 }

--- a/src/utils/slot.tsx
+++ b/src/utils/slot.tsx
@@ -1,0 +1,41 @@
+import type { HTMLAttributes, ReactElement, ReactNode } from "react"
+
+import { Children, cloneElement, isValidElement } from "react"
+
+import { Slottable } from "./slottable"
+
+interface SlotProps extends HTMLAttributes<HTMLElement> {
+  children: ReactNode
+}
+
+export function Slot({ children, ...restProps }: SlotProps) {
+  const childrenArray = Children.toArray(children)
+  const slottable = childrenArray.find((child) => isValidElement(child) && child.type === Slottable) as ReactElement<{
+    children: ReactNode
+  }>
+
+  if (slottable) {
+    const newElement = slottable.props.children
+    const newChildren = childrenArray.map((child) => {
+      if (child !== slottable) {
+        return child
+      }
+
+      if (Children.count(newElement) > 1) {
+        console.warn("Slottable은 단일 요소로만 사용해야 합니다.")
+        return Children.only(null)
+      }
+
+      return isValidElement(newElement) ? (newElement.props as { children: ReactNode }).children : null
+    })
+
+    return isValidElement(newElement) ? cloneElement(newElement, restProps, newChildren) : null
+  }
+
+  if (Children.count(children) > 1) {
+    console.warn("Slottable은 단일 요소로만 사용해야 합니다.")
+    return Children.only(null)
+  }
+
+  return isValidElement(children) ? cloneElement(children, restProps) : null
+}

--- a/src/utils/slot.tsx
+++ b/src/utils/slot.tsx
@@ -11,6 +11,15 @@ interface SlotProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode
 }
 
+/**
+ * 상위 컴포넌트가 하위 컴포넌트에게 렌더링을 위임하는 유틸리티 컴포넌트
+ * @param children - 하위 컴포넌트
+ * @param restProps - 나머지 속성
+ * @param forwardedRef - 상위 컴포넌트에서 전달된 ref
+ * @returns ReactElement
+ *
+ * @see {@link https://github.com/radix-ui/primitives/blob/main/packages/react/slot/src/slot.tsx Radix UI의 Slot 참조}
+ */
 export const Slot = forwardRef<HTMLElement, SlotProps>(({ children, ...restProps }, forwardedRef) => {
   const childrenArray = Children.toArray(children)
   const slottable = childrenArray.find((child) => isValidElement(child) && child.type === Slottable) as ReactElement<{

--- a/src/utils/slot.tsx
+++ b/src/utils/slot.tsx
@@ -59,6 +59,15 @@ export const Slot = forwardRef<HTMLElement, SlotProps>(({ children, ...restProps
 
 Slot.displayName = "Slot"
 
+/**
+ * ReactElement의 ref를 추출하는 유틸리티 함수
+ * @param element - ReactElement
+ * @returns Ref<unknown>
+ *
+ * @see {@link https://github.com/radix-ui/primitives/blob/main/packages/react/slot/src/slot.tsx#L203 Radix UI의 getElementRef 참조}
+ *
+ * React 19에서는 element.props.ref를 사용해야하지만, 그 미만 버전에서는 element.ref로 접근합니다. 따라서 버전 차이로 인한 console.error를 방지하기 위해 두 가지를 모두 확인합니다.
+ */
 function getElementRef(element: ReactElement) {
   return (element.props as { ref?: Ref<unknown> }).ref || (element as unknown as { ref?: Ref<unknown> }).ref
 }

--- a/src/utils/slottable.tsx
+++ b/src/utils/slottable.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react"
+
+export function Slottable({ children }: { children: ReactNode }) {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>
+}


### PR DESCRIPTION
# 📝 개요

- 상위 컴포넌트와 하위 컴포넌트에 ref를 모두 지원할 수 있도록 `composeRefs` 함수 구현
- `getElementRef` 함수로 ref를 가져올 수 있도록 구현

> [!WARNING]
> React 19버전에서는 `ReactElement.props.ref`로 가져와야한다는 에러가 발생합니다. 따라서 React 19버전 미만의 버전들도 고려할 수 있도록 `ReactElement.ref` 형태도 가능하도록 작성했습니다.

## 🔗 관련 이슈

- Closes #21 

## 🛠️ 변경 사항 (Checklist)

- [ ] ✨ Feature: 새로운 기능 추가
- [x] 🚀 Enhancement: 기존 기능 개선/성능 향상
- [ ] 🐞 Bug: 버그 수정
- [ ] ♻️ Refactor: 코드 구조 개선 (기능 변화 없음)
- [ ] 🏗️ Chore: 빌드/패키지 설정/단순 잡일
- [ ] 🎨 Design: UI/UX 스타일 수정
- [ ] 📚 Documentation: 문서 수정

## 🧪 테스트 결과

- [x] 단위 테스트(Unit Test) 통과

## ✅ 나를 위한 자가 체크리스트 (Self-Check)

### 1. 의도와 가독성 (Naming & Readability)

- [x] **의도 중심 네이밍**: 변수명에서 '역할'이, 함수명에서 '행위+대상'이 명확히 드러나나요?
- [x] **선언적 코드**: '어떻게'가 아닌 '무엇을' 하는지 코드만 보고도 알 수 있나요? (복잡한 로직은 내부 메서드로 숨겼나요?)
- [x] **주석**: 코드만으로 설명이 어려운 '특이 로직'에만 주석을 달았나요?

### 2. 타입과 논리 (Type Safety & Logic)

- [x] **타입 안전성**: `any` 사용을 지양하고, 모든 함수의 반환 타입을 명시했나요?
- [x] **엣지 케이스**: 데이터가 없거나(`null/undefined`), 에러가 발생할 경우를 처리했나요?
- [x] **하드코딩 방지**: API 주소나 설정값들이 환경 변수나 상수로 분리되었나요?

### 3. 코드 다이어트 (Clean-up)

- [x] **찌꺼기 제거**: 디버깅용 `console.log`나 사용하지 않는 `import`를 모두 지웠나요?
- [x] **불필요한 코드**: "나중에 쓰겠지" 하고 남겨둔 죽은 코드(Dead Code)는 없나요?
- [x] **Linter**: 린트 에러나 워닝이 남아있지 않나요?

### 4. 지속 가능성 (Sustainability)

- [x] **테스트**: 수동으로든 코드로든 정상 작동을 확인했나요? (특히 기존 기능이 망가지지 않았나요?)
- [x] **문서화**: 새로운 환경 변수나 라이브러리가 추가되어 `README` 업데이트가 필요한가요?

---

## 💭 오늘의 회고 (Optional)

컴포넌트를 잘 합성한다는건 생각보다 많이 어려운 일인것 같다. 이런 사고 과정을 거치기위해 Radix 팀에서 오랜 시간이 걸렸을것 같다. 덕분에 나는 이 사람들이 무엇을 고려했을지 엿볼수 있어 좋은것 같다.

물론 지금 PR에서는 많이 참조를 했기 때문에 내가 구현한 것이라고 볼 순 없다. 따로 블로그 포스팅을 하거나 혼자 다시 상기하고 만들어보면서 사고를 확장하는 연습이 반드시 필요할 것 같다.

추가적으로 React 19버전에서는 forwardRef를 없애려고 한다. 19버전 미만에서는 ref의 값을 가져오기 위해 Element.ref로 접근하여 가져왔었고, 이러한 이유로 forwardRef가 필요했었는데, 지금은 Element.props.ref로 가져오려는 시도를 하고 있다고한다.